### PR TITLE
fix: evita recarregamento desnecessário ao carregar a mesma sessão sem alterações

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -404,9 +404,7 @@ def manage_sessions(sessions_dir, action):
                         session_already_loaded = True
                     
                     if session_already_loaded:
-                        print()  # Linha em branco para espaçamento
-                        message = get_session_status_message(session_name)
-                        print(message)
+                        print(f"ℹ️ Sessão '{session_name}' já está carregada e ativa. Nenhuma alteração detectada.")
                         time.sleep(2)
                         return {"type": "active", "file": session_name, "loaded": False, "already_loaded": True}
                 elif force_reload:


### PR DESCRIPTION
Agora, ao tentar carregar a mesma sessão já ativa e sem modificações, o sistema apenas avisa que ela já está carregada e retorna ao menu, mantendo o estado atual.
