### PR TITLE
fix: corrige mensagens de vinculação de personalidade para refletir tipo correto de sessão

### DIFF
--- a/modules/data_adapter.py
+++ b/modules/data_adapter.py
@@ -278,8 +278,10 @@ class DataAdapter:
                     else:
                         # Vincula à sessão ativa (salva ou temporária)
                         self.db.add_to_session(target_session, [existing_personality['id']])
-                        session_type = f"sessão '{self.active_saved_session}'" if self.active_saved_session else "sessão temporária"
-                        print(f"🔗 '{full_name}' vinculada à {session_type}")
+                        if self.active_saved_session:
+                            print(f"✅ Personalidade vinculada à sessão '{self.active_saved_session}'")
+                        else:
+                            print(f"✅ Personalidade vinculada à sessão temporária")
                 
                 # Retorna os dados da personalidade encontrada
                 

--- a/modules/info_gathering.py
+++ b/modules/info_gathering.py
@@ -35,7 +35,7 @@ def fetch_data(search_term, is_correct_term):
         print(f"   Nome: {existing_data.get('full_name', 'N/A')}")
         print(f"   País: {existing_data.get('country', 'N/A')}")
         print(f"   Século: {existing_data.get('century', 'N/A')}")
-        print("✅ Personalidade vinculada à sessão temporária")
+        # Mensagem já é exibida corretamente pela função smart_search_and_add
         time.sleep(3)
         return
 
@@ -61,7 +61,7 @@ def fetch_data(search_term, is_correct_term):
             print(f"   Nome: {existing_corrected_data.get('full_name', 'N/A')}")
             print(f"   País: {existing_corrected_data.get('country', 'N/A')}")
             print(f"   Século: {existing_corrected_data.get('century', 'N/A')}")
-            print("✅ Personalidade vinculada à sessão temporária")
+            # Mensagem já é exibida corretamente pela função smart_search_and_add
             time.sleep(3)
             return
         else:


### PR DESCRIPTION
- Remove mensagens duplicadas que sempre mostravam "sessão temporária"
- Agora a função smart_search_and_add exibe corretamente se é sessão salva ou temporária
- Melhora feedback ao usuário sobre onde a personalidade foi vinculada
